### PR TITLE
Fixes #25: fixed zipkin configuration

### DIFF
--- a/src/main/java/com/redhat/developers/msa/api_gateway/CamelConfiguration.java
+++ b/src/main/java/com/redhat/developers/msa/api_gateway/CamelConfiguration.java
@@ -70,21 +70,17 @@ public class CamelConfiguration {
 
         // Map Camel endpoints to names
         Map<String, String> clientConfig = new HashMap<>();
-        clientConfig.put("http4:aloha:*", "aloha");
-        clientConfig.put("http4:hola:*", "hola");
-        clientConfig.put("http4:ola:*", "ola");
-        clientConfig.put("http4:bonjour:*", "bonjour");
+        clientConfig.put("http4:*", "api-gateway");
 
         zipkin.setClientServiceMappings(clientConfig);
 
         // Map consumer endpoints to names
         Map<String, String> serverConfig = new HashMap<>();
-        serverConfig.put("servlet:*", "api-gateway");
+        serverConfig.put("rest:*", "api-gateway");
 
         zipkin.setServerServiceMappings(serverConfig);
 
         // Tracer configuration
-        zipkin.setServiceName("api-gateway");
         zipkin.setIncludeMessageBody(true);
         zipkin.setIncludeMessageBodyStreams(true);
         String zipkinUrl = System.getenv("ZIPKIN_SERVER_URL");

--- a/src/main/java/com/redhat/developers/msa/api_gateway/CamelRestEndpoints.java
+++ b/src/main/java/com/redhat/developers/msa/api_gateway/CamelRestEndpoints.java
@@ -51,7 +51,7 @@ public class CamelRestEndpoints extends RouteBuilder {
 
 
         /*
-         * Ciao service
+         * Gateway service
          */
 
         // full path: /api/gateway


### PR DESCRIPTION
There was a wrong zipkin configuration that was discovered after the upgrade done few days ago.

I've also removed the internal nodes. The spans generated now are equivalent to the ones of the other version of the api-gateway.