### PR TITLE
ERROR: No api-gateway.jar found in /deployments.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -190,7 +190,7 @@
 							<build>
 								<from>${docker.from}</from>
 								<assembly>
-									<basedir>/app</basedir>
+									<basedir>/deployments</basedir>
 									<descriptorRef>artifact</descriptorRef>
 								</assembly>
 								<env>


### PR DESCRIPTION
When using `mvn clean package docker:build …`.